### PR TITLE
workaround for template keys with special characters + tests

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -175,6 +175,12 @@ func RunTemplate(templateContent string, data interface{}, out io.Writer) error 
 		"age": func(content string) (string, error) {
 			return FuzzyAge(content)
 		},
+		"specialCharMap": func(m map[string]interface {}, key string) interface {} {
+		    if val, ok := m[key]; ok {
+			    return val
+		    }
+		    return nil
+		},
 	}
 	if tmpl, err := template.New("template").Funcs(funcs).Parse(templateContent); err != nil {
 		log.Error("Failed to parse template: %s", err)

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,0 +1,75 @@
+package util
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+type Options struct {
+	AliasOpts                  map[string]interface{}
+}
+
+type CommandData struct {
+	Options
+	AliasOpts map[string]interface{}
+}
+
+// Test to prove templating doesn't natively fetch keys with special characters, i.e. '-'
+func TestRunTemplateWithDashOptNameFails(t *testing.T) {
+	options := Options {
+			map[string]interface {}{"enable-debug": false},
+	}
+	data := CommandData{
+		Options: options,
+	}
+	buf := bytes.NewBufferString("")
+	err := RunTemplate(`{{ .Options.AliasOpts.enable-debug }}`, data, buf)
+	if err != nil {
+		if !strings.Contains(err.Error(), "bad character U+002D '-'") {
+			t.Error(err)
+		}
+	} else {
+		t.Error("expected this to not work")
+	}
+}
+
+// Workaround to fetch keys with special characters, i.e. '-'
+func TestRunTemplateWithDashOptName(t *testing.T) {
+	options := Options {
+			map[string]interface {}{"enable-debug": false},
+	}
+	data := CommandData{
+		Options: options,
+	}
+	buf := bytes.NewBufferString("")
+	err := RunTemplate(`{{ specialCharMap .Options.AliasOpts "enable-debug" }}`, data, buf)
+	if err != nil {
+		log.Errorf("Failed to process template")
+		t.Fail()
+	}
+
+	if buf.String() != "false" {
+		t.Error("expected false, but got : " + buf.String())
+	}
+}
+
+// Test if you ask for a non-existent key you get <no value>
+func TestRunTemplateWithNonexistentKey(t *testing.T) {
+	options := Options {
+			map[string]interface {}{"foo": false},
+	}
+	data := CommandData{
+		Options: options,
+	}
+	buf := bytes.NewBufferString("")
+	err := RunTemplate(`{{ specialCharMap .Options.AliasOpts "enable-debug" }}`, data, buf)
+	if err != nil {
+		log.Errorf("Failed to process template")
+		t.Fail()
+	}
+
+	if buf.String() != "<no value>" {
+		t.Error("expected nil, but got : " + buf.String())
+	}
+}


### PR DESCRIPTION
The template library doesn't allow accessing keys with special characters.  This is a workaround based on : http://stackoverflow.com/questions/24267608/how-to-print-the-value-of-a-key-containing-dots

Our use case is to match the options of a newt alias command to a native command (enable-debug).
